### PR TITLE
docs(v4.4): update Oracle compatibility section and fix typos

### DIFF
--- a/CN/modules/ROOT/pages/v4.4/15.adoc
+++ b/CN/modules/ROOT/pages/v4.4/15.adoc
@@ -33,7 +33,7 @@
 | nls_length_semantics | 兼容Oracle的同名参数，控制一个字符所占内存的大小
 | nls_timestamp_format | 兼容Oracle的同名参数，控制带时间的日期格式
 | nls_timestamp_tz_format | 兼容Oracle的同名参数，控制带时区的日期格式
-| shared_preload_libraries | 在初始话数据库时，从ivorysql.conf文件中读取，可以通过show命令查看，在配置文件中修改该值，重启数据库生效。
+| shared_preload_libraries | 在初始化数据库时，从ivorysql.conf文件中读取，可以通过show命令查看，在配置文件中修改该值，重启数据库生效。
 |====
 
 === 部分变量使用示例

--- a/CN/modules/ROOT/pages/v4.4/8.adoc
+++ b/CN/modules/ROOT/pages/v4.4/8.adoc
@@ -1959,25 +1959,9 @@ SELECT concat_lower_or_upper('Hello', 'World', uppercase => true);
 
 == Oracle兼容功能
 
-=== 配置参数
+**详见：**
 
-参数设置采用与原生 PostgreSQL 相同的方法。 所有参数名称都不区分大小写。每个参数都采用以下五种类型之一的值：布尔值、字符串、整数、浮点数或枚举 (enum)。
-
-==== `ivorysql.compatible_mode (enum)`
-
-此参数控制数据库服务器的行为。 如果它设置为`pg`，表示它是原生安装，服务器将作为原生 PG 安装。 如果它设置为“oracle”，那么查询的输出和系统行为整体会发生变化，因为它会更像 Oracle。
-
-当设置为 `oracle` 时，此参数会隐式地将同样名字的Schema添加到 `search_path`。 以便可以定位 Oracle 兼容对象。
-
-该参数可以通过 `postgresql.conf` 配置文件设置，对整个数据库生效。 或者可以通过客户端使用 `set` 命令在会话上进行设置。
-
-==== `nls_length_semantics (enum)`
-
-此参数控制如何根据长度语义创建 `CHAR` 和 `VARCHAR2` 列。 默认设置为 `NONE`，这不会产生任何影响。 `BYTE` 可以设置为以字节长度语义存储数据。 `CHAR` 使用字符长度语义。
-
-**标识：**
-
-- https://www.ivorysql.org/zh-CN/docs/tags/compatibility-parameters[Compatibility Parameters]
+- [GUC变量](https://docs.ivorysql.org/cn/ivorysql-doc/v4.4/v4.4/15)
 
 === 更改表
 

--- a/EN/modules/ROOT/pages/v4.4/8.adoc
+++ b/EN/modules/ROOT/pages/v4.4/8.adoc
@@ -2078,15 +2078,9 @@ Named and mixed call notations currently cannot be used when calling an aggregat
 
 == Oracle Compatible Features
 
-=== Configuration parameters
+**Refer to:**
 
-Parameters are set in the same way as in native IvorySQL. All parameter names are case-insensitive. Each parameter takes a value of one of the following five types: boolean, string, integer, floating point, or enum.
-
-==== `ivorysql.compatible_mode (enum)`
-
-This parameter controls the behavior of the database server. If it is set to `pg`, which means it is a native installation and the server will be installed as a native PG. If it is set to `oracle`, then the query output and overall system behavior will change, as it will be more Oracle-like.
-
-When set to `oracle`, this parameter will implicitly add a Schema with the same name to `search_path`. so that Oracle-compatible objects can be located.
+- [GUC Variables](https://docs.ivorysql.org/en/ivorysql-doc/v4.4/v4.4/15)
 
 === Changing tables
 


### PR DESCRIPTION
- Remove detailed configuration parameters from Oracle compatibility section
- Add reference link to GUC Variables page
- Fix typo in shared_preload_libraries description
- Update both Chinese and English documents