### PR TITLE
Remove unnecessary dependencies from Groonga installation guide

### DIFF
--- a/CN/modules/ROOT/pages/v4.6/34.adoc
+++ b/CN/modules/ROOT/pages/v4.6/34.adoc
@@ -20,25 +20,6 @@ PGroonga 应运而生，它是一个 PostgreSQL 的扩展插件，将 ​​Groo
 
 ==== 安装 groonga
 
-** 安装依赖 kytea
-```
-git clone https://github.com/neubig/kytea.git
-autoreconf -i
-./configure
-make
-sudo make install
-```
-
-** 安装依赖 libzmq
-```
-从https://github.com/zeromq/libzmq/releases/tag/v4.3.5 下载zeromq-4.3.5.tar.gz
-tar xvf zeromq-4.3.5.tar.gz
-cd zeromq-4.3.5/
-./configure
-make
-sudo make install
-```
-
 ** 下载 groonga包，安装指定依赖
 ```
 wget https://packages.groonga.org/source/groonga/groonga-latest.tar.gz

--- a/EN/modules/ROOT/pages/v4.6/34.adoc
+++ b/EN/modules/ROOT/pages/v4.6/34.adoc
@@ -19,25 +19,6 @@ IvorySQL 4.6 or higher version is already installed in the environment, with the
 
 ==== Install groonga
 
-** Install dependency kytea
-```
-git clone https://github.com/neubig/kytea.git
-autoreconf -i
-./configure
-make
-sudo make install
-```
-
-** Install dependency libzmq
-```
-Download zeromq-4.3.5.tar.gz from https://github.com/zeromq/libzmq/releases/tag/v4.3.5
-tar xvf zeromq-4.3.5.tar.gz
-cd zeromq-4.3.5/
-./configure
-make
-sudo make install
-```
-
 ** Download groonga package and install specified dependencies
 ```
 wget https://packages.groonga.org/source/groonga/groonga-latest.tar.gz


### PR DESCRIPTION
Remove KyTea and ZeroMQ (libzmq) installation steps from the PGroonga setup documentation. These dependencies are not required for using PGroonga with IvorySQL.

- KyTea: Rarely used and not required even with release-maximum preset
- ZeroMQ: Only required when using Groonga via groonga-suggest-httpd, not needed when using Groonga through PGroonga

Tested and confirmed that PGroonga works correctly without these dependencies in both package installation and source build scenarios on AlmaLinux 9 with IvorySQL 4.6 and PostgreSQL 17.6.