### PR TITLE
docs: add IvorySQL community Harbor registry tips for Chinese users

### DIFF
--- a/CN/modules/ROOT/pages/3.1.adoc
+++ b/CN/modules/ROOT/pages/3.1.adoc
@@ -120,6 +120,8 @@ ivorysql  3238  1551  0 20:35 pts/0    00:00:00 grep --color=auto postgres
 $ docker pull ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
+TIP: 国内用户可使用 IvorySQL 社区的 Harbor 镜像服务（https://registry.highgo.com/[https://registry.highgo.com/]）加速拉取，例如：`docker pull registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`。
+
 ** 运行IvorySQL
 
 [source,bash,subs="attributes"]

--- a/CN/modules/ROOT/pages/3.1.adoc
+++ b/CN/modules/ROOT/pages/3.1.adoc
@@ -120,7 +120,7 @@ ivorysql  3238  1551  0 20:35 pts/0    00:00:00 grep --color=auto postgres
 $ docker pull ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
-TIP: 国内用户可使用 IvorySQL 社区的 Harbor 镜像服务（https://registry.highgo.com/[https://registry.highgo.com/]）加速拉取，例如：`docker pull registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`。
+TIP: 国内用户也可使用 IvorySQL 社区的 Harbor 镜像服务加速拉取，例如：`docker pull registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`。
 
 ** 运行IvorySQL
 

--- a/CN/modules/ROOT/pages/4.1.adoc
+++ b/CN/modules/ROOT/pages/4.1.adoc
@@ -46,7 +46,7 @@ $ sudo dnf install -y ivorysql5-{ivorysql-version}
 $ docker pull ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
-TIP: 国内用户也可使用 IvorySQL 社区的 Harbor 镜像服务（https://registry.highgo.com/[https://registry.highgo.com/]）加速拉取，将上述地址替换为 `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8` 即可。
+TIP: 国内用户也可使用 IvorySQL 社区的 Harbor 镜像服务加速拉取，将上述地址替换为 `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8` 即可。
 
 ** 运行IvorySQL
 

--- a/CN/modules/ROOT/pages/4.1.adoc
+++ b/CN/modules/ROOT/pages/4.1.adoc
@@ -46,6 +46,8 @@ $ sudo dnf install -y ivorysql5-{ivorysql-version}
 $ docker pull ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
+TIP: 国内用户也可使用 IvorySQL 社区的 Harbor 镜像服务（https://registry.highgo.com/[https://registry.highgo.com/]）加速拉取，将上述地址替换为 `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8` 即可。
+
 ** 运行IvorySQL
 
 [source,bash,subs="attributes"]

--- a/CN/modules/ROOT/pages/4.6.4.adoc
+++ b/CN/modules/ROOT/pages/4.6.4.adoc
@@ -6,7 +6,7 @@
 
 [TIP]
 ====
-除 Docker Hub 外，IvorySQL 社区还为国内用户提供 Harbor 镜像服务：https://registry.highgo.com/[https://registry.highgo.com/]。将本章节中的镜像地址前缀替换为 `registry.highgo.com/` 即可使用，例如 `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`。
+除 Docker Hub 外，IvorySQL 社区还为国内用户提供 Harbor 镜像服务。将本章节中的镜像地址前缀替换为 `registry.highgo.com/` 即可使用，例如 `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`。
 ====
 
 == docker方式运行

--- a/CN/modules/ROOT/pages/4.6.4.adoc
+++ b/CN/modules/ROOT/pages/4.6.4.adoc
@@ -4,6 +4,11 @@
 
 = Docker & Podman 部署IvorySQL
 
+[TIP]
+====
+除 Docker Hub 外，IvorySQL 社区还为国内用户提供 Harbor 镜像服务：https://registry.highgo.com/[https://registry.highgo.com/]。将本章节中的镜像地址前缀替换为 `registry.highgo.com/` 即可使用，例如 `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`。
+====
+
 == docker方式运行
 
 ** 从Docker Hub上获取IvorySQL镜像

--- a/CN/modules/ROOT/pages/4.7.1.adoc
+++ b/CN/modules/ROOT/pages/4.7.1.adoc
@@ -364,6 +364,8 @@ https://github.com/IvorySQL/ivory-operator/tree/IVYO_REL_5_STABLE[https://github
 
 如果服务器可以直接访问到docker hub,可以跳过该章节。否则需要在所有的K8S集群节点提前load 如下docker镜像
 
+TIP: 国内用户可使用 IvorySQL 社区的 Harbor 镜像服务（https://registry.highgo.com/[https://registry.highgo.com/]）拉取以下镜像，将 `docker.io/` 替换为 `registry.highgo.com/` 即可。
+
 [literal]
 ----
 docker.io/ivorysql/pgadmin:ubi8-9.9-5.0-1

--- a/CN/modules/ROOT/pages/4.7.1.adoc
+++ b/CN/modules/ROOT/pages/4.7.1.adoc
@@ -364,7 +364,7 @@ https://github.com/IvorySQL/ivory-operator/tree/IVYO_REL_5_STABLE[https://github
 
 如果服务器可以直接访问到docker hub,可以跳过该章节。否则需要在所有的K8S集群节点提前load 如下docker镜像
 
-TIP: 国内用户可使用 IvorySQL 社区的 Harbor 镜像服务（https://registry.highgo.com/[https://registry.highgo.com/]）拉取以下镜像，将 `docker.io/` 替换为 `registry.highgo.com/` 即可。
+TIP: 国内用户也可使用 IvorySQL 社区的 Harbor 镜像服务拉取以下镜像，将 `docker.io/` 替换为 `registry.highgo.com/` 即可。
 
 [literal]
 ----

--- a/EN/modules/ROOT/pages/3.1.adoc
+++ b/EN/modules/ROOT/pages/3.1.adoc
@@ -114,7 +114,7 @@ ivorysql  3238  1551  0 20:35 pts/0    00:00:00 grep --color=auto postgres
 $ docker pull ivorysql/IvorySQL {ivorysql-version}-ubi8
 ```
 
-TIP: Users in China can also pull from the IvorySQL community Harbor registry (https://registry.highgo.com/[https://registry.highgo.com/]) for faster downloads, e.g. `docker pull registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
+TIP: Users in China can also pull from the IvorySQL community Harbor registry for faster downloads, e.g. `docker pull registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
 
 ** Running IvorySQL
 

--- a/EN/modules/ROOT/pages/3.1.adoc
+++ b/EN/modules/ROOT/pages/3.1.adoc
@@ -114,6 +114,8 @@ ivorysql  3238  1551  0 20:35 pts/0    00:00:00 grep --color=auto postgres
 $ docker pull ivorysql/IvorySQL {ivorysql-version}-ubi8
 ```
 
+TIP: Users in China can also pull from the IvorySQL community Harbor registry (https://registry.highgo.com/[https://registry.highgo.com/]) for faster downloads, e.g. `docker pull registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
+
 ** Running IvorySQL
 
 [source,bash,subs="attributes"]

--- a/EN/modules/ROOT/pages/4.1.adoc
+++ b/EN/modules/ROOT/pages/4.1.adoc
@@ -47,7 +47,7 @@ $ sudo dnf install -y ivorysql5-{ivorysql-version}
 $ docker pull ivorysql/IvorySQL {ivorysql-version}-ubi8
 ```
 
-TIP: Users in China can also pull from the IvorySQL community Harbor registry (https://registry.highgo.com/[https://registry.highgo.com/]) for faster downloads — replace the image reference above with `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
+TIP: Users in China can also pull from the IvorySQL community Harbor registry for faster downloads — replace the image reference above with `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
 
 ** Run IvorySQL
 

--- a/EN/modules/ROOT/pages/4.1.adoc
+++ b/EN/modules/ROOT/pages/4.1.adoc
@@ -47,6 +47,8 @@ $ sudo dnf install -y ivorysql5-{ivorysql-version}
 $ docker pull ivorysql/IvorySQL {ivorysql-version}-ubi8
 ```
 
+TIP: Users in China can also pull from the IvorySQL community Harbor registry (https://registry.highgo.com/[https://registry.highgo.com/]) for faster downloads — replace the image reference above with `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
+
 ** Run IvorySQL
 
 [source,bash,subs="attributes"]

--- a/EN/modules/ROOT/pages/4.6.4.adoc
+++ b/EN/modules/ROOT/pages/4.6.4.adoc
@@ -4,6 +4,11 @@
 
 = Docker & Podman deployment IvorySQL
 
+[TIP]
+====
+In addition to Docker Hub, the IvorySQL community also provides a Harbor registry for users in China: https://registry.highgo.com/[https://registry.highgo.com/]. Replace the image prefix used in this chapter with `registry.highgo.com/`, e.g. `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
+====
+
 == Running IvorySQL in docker
 
 ** Get IvorySQL image from Docker Hub

--- a/EN/modules/ROOT/pages/4.6.4.adoc
+++ b/EN/modules/ROOT/pages/4.6.4.adoc
@@ -6,7 +6,7 @@
 
 [TIP]
 ====
-In addition to Docker Hub, the IvorySQL community also provides a Harbor registry for users in China: https://registry.highgo.com/[https://registry.highgo.com/]. Replace the image prefix used in this chapter with `registry.highgo.com/`, e.g. `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
+In addition to Docker Hub, the IvorySQL community also provides a Harbor registry for users in China. Replace the image prefix used in this chapter with `registry.highgo.com/`, e.g. `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
 ====
 
 == Running IvorySQL in docker

--- a/EN/modules/ROOT/pages/4.7.1.adoc
+++ b/EN/modules/ROOT/pages/4.7.1.adoc
@@ -363,6 +363,8 @@ https://github.com/IvorySQL/ivory-operator/tree/IVYO_REL_5_STABLE[https://github
 
 If your servers have direct access to Docker Hub, you can skip this step. Otherwise, preload the following images on every node in the Kubernetes cluster.
 
+TIP: Users in China can pull the following images from the IvorySQL community Harbor registry (https://registry.highgo.com/[https://registry.highgo.com/]) by replacing the `docker.io/` prefix with `registry.highgo.com/`.
+
 [literal]
 ----
 docker.io/ivorysql/pgadmin:ubi8-9.9-5.0-1

--- a/EN/modules/ROOT/pages/4.7.1.adoc
+++ b/EN/modules/ROOT/pages/4.7.1.adoc
@@ -363,7 +363,7 @@ https://github.com/IvorySQL/ivory-operator/tree/IVYO_REL_5_STABLE[https://github
 
 If your servers have direct access to Docker Hub, you can skip this step. Otherwise, preload the following images on every node in the Kubernetes cluster.
 
-TIP: Users in China can pull the following images from the IvorySQL community Harbor registry (https://registry.highgo.com/[https://registry.highgo.com/]) by replacing the `docker.io/` prefix with `registry.highgo.com/`.
+TIP: Users in China can pull the following images from the IvorySQL community Harbor registry by replacing the `docker.io/` prefix with `registry.highgo.com/`.
 
 [literal]
 ----


### PR DESCRIPTION
Add concise TIP notes in Docker-related sections pointing to the new community Harbor mirror (https://registry.highgo.com/) so users in China can pull images faster. Applied symmetrically across EN/ and CN/ in the Quick Start, Installation, Docker & Podman deployment, and Operator image-preload pages.