### PR TITLE
ci: pin @antora/pdf-extension to 1.0.0-beta.20 (fix build FATAL)

### DIFF
--- a/.github/workflows/merge-build-push.yml
+++ b/.github/workflows/merge-build-push.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Install Antora CLI
         run: |
           echo "Installing Antora packages local..."
-          npm install --global antora@3.1.7  @antora/lunr-extension  @antora/pdf-extension  @node-rs/jieba
+          npm install --global antora@3.1.7  @antora/lunr-extension  @antora/pdf-extension@1.0.0-beta.20  @node-rs/jieba
 
       - name: Build English Documentation
         working-directory: ./ivory-doc-builder

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install Antora CLI
         run: |
           echo "Installing Antora packages local..."
-          npm install --global antora@3.1.7  @antora/lunr-extension  @antora/pdf-extension  @node-rs/jieba
+          npm install --global antora@3.1.7  @antora/lunr-extension  @antora/pdf-extension@1.0.0-beta.20  @node-rs/jieba
 
       - name: Build English Documentation
         working-directory: ./ivory-doc-builder


### PR DESCRIPTION
## Problem

PR #271 and other doc builds fail with:
```
FATAL (antora): contentCatalog.createFile is not a function
```

## Root cause

The CI installs Antora pinned (`antora@3.1.7`) but `@antora/pdf-extension` **unpinned**. On **2026-06-29**, `@antora/pdf-extension@1.0.0-rc.1` was published, which bundles `@antora/assembler@1.0.0-rc.1`. That assembler calls `contentCatalog.createFile()` — a method that does not exist in `@antora/content-classifier@3.1.10` (the ContentCatalog used by `antora@3.1.7`). The previous version `1.0.0-beta.20` did not use it, so builds passed until the new release.

## Fix

Pin `@antora/pdf-extension` to the last-known-good `1.0.0-beta.20` in both workflow install steps (`pr-preview.yml`, `merge-build-push.yml`), restoring the working toolchain alongside `antora@3.1.7`.

> Note: `pr-preview.yml` runs via `pull_request_target`, so this fix only takes effect for new PR previews once merged into the base branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)