### PR TITLE
Fix duplicate Antora component version on v1.23 branch

### DIFF
--- a/CN/antora.yml
+++ b/CN/antora.yml
@@ -1,6 +1,6 @@
 name: ivorysql-doc
 title: IvorySQL
-version: v1.22
+version: v1.23
 start_page: v1.22/welcome.adoc
 asciidoc:
   attributes:

--- a/EN/antora.yml
+++ b/EN/antora.yml
@@ -1,6 +1,6 @@
 name: ivorysql-doc
 title: IvorySQL
-version: v1.22
+version: v1.23
 start_page: v1.22/welcome.adoc
 asciidoc:
   attributes:


### PR DESCRIPTION
EN/antora.yml and CN/antora.yml on the v1.23 branch both declared version: v1.22, colliding with the v1.22 branch. Antora rejects two branches producing the same component+version (duplicate nav.adoc), causing a FATAL build error. Bump both to v1.23.