### PR TITLE
docs: add IvorySQL 5 PoWA adaptation guide

### DIFF
--- a/CN/modules/ROOT/nav.adoc
+++ b/CN/modules/ROOT/nav.adoc
@@ -76,6 +76,7 @@
 *** xref:master/ecosystem_components/zhparser.adoc[zhparser]
 *** xref:master/ecosystem_components/pgbackrest.adoc[pgBackRest]
 *** xref:master/ecosystem_components/set_user.adoc[set_user]
+*** xref:master/ecosystem_components/powa.adoc[PoWA]
 * 监控运维
 ** xref:master/getting-started/daily_monitoring.adoc[日常监控]
 ** xref:master/getting-started/daily_maintenance.adoc[日常维护]

--- a/CN/modules/ROOT/pages/master/ecosystem_components/ecosystem_overview.adoc
+++ b/CN/modules/ROOT/pages/master/ecosystem_components/ecosystem_overview.adoc
@@ -41,6 +41,7 @@ IvorySQL 作为一款兼容 Oracle 且基于 PostgreSQL 的高级开源数据库
 | 28 | xref:master/ecosystem_components/zhparser.adoc[zhparser] | master branch | 用于中文全文搜索的PostgreSQL插件，基于SCWS（即：简易中文分词系统）实现了一个中文解析器 | 搜索引擎、关键字提取
 | 29 | xref:master/ecosystem_components/pgbackrest.adoc[pgBackRest] | 2.58.0 | 可靠的 PostgreSQL 备份和恢复解决方案 | 容灾备份、大库备份、异地/多层容灾
 | 30 | xref:master/ecosystem_components/set_user.adoc[set_user] | REL4_2_0 | PostgreSQL 安全审计扩展，可控角色切换，支持白名单、强制审计、拦截高危操作 | 可控角色切换、权限管理、审计日志
+| 31 | xref:master/ecosystem_components/powa.adoc[PoWA] | 5.3.0 | 采集并可视化数据库工作负载统计 | 性能监控、负载分析、查询调优
 |====
 
 这些插件均经过 IvorySQL 团队的测试和适配，确保在 IvorySQL 环境下稳定运行。用户可以根据业务需求选择合适的插件，进一步提升数据库系统的能力和灵活性。

--- a/CN/modules/ROOT/pages/master/ecosystem_components/powa.adoc
+++ b/CN/modules/ROOT/pages/master/ecosystem_components/powa.adoc
@@ -1,0 +1,100 @@
+:sectnums:
+:sectnumlevels: 5
+
+= PoWA
+
+== 概述
+
+PoWA（PostgreSQL Workload Analyzer）用于采集数据库工作负载统计，并通过 Web 界面展示。完整部署可以包含：
+
+* `powa-archivist`：在数据库中存储和聚合指标的扩展；
+* `powa-web`：可视化界面；
+* `powa-collector`：从多个远程服务器采集指标的可选守护进程。
+
+`pg_stat_statements` 是必需的主要数据源，其他统计扩展均为可选项。
+
+本文在 x86_64 Linux 上使用 IvorySQL 5.4（PostgreSQL 18.4）和 PoWA Archivist 5.3.0 完成验证。扩展无需修改源码即可编译，8 项上游 PostgreSQL 回归测试全部通过。
+
+== 选择部署模式
+
+*本地模式*由 PoWA 后台工作进程在被监控的 IvorySQL 实例中采集并存储指标，适合快速评估，但采集、存储和可视化查询都会增加该实例的负载。
+
+*远程模式*由 `powa-collector` 从被监控实例读取统计信息并写入专用仓库。生产环境推荐该架构，因为它可把存储和可视化开销移出业务数据库，并支持监控只读备库。
+
+== 编译 PoWA Archivist
+
+安装 IvorySQL 服务端开发文件，然后使用相匹配的 `pg_config` 编译：
+
+[source,bash]
+----
+git clone --branch REL_5_3_0 --depth 1 \
+  https://github.com/powa-team/powa-archivist.git
+cd powa-archivist
+
+make PG_CONFIG=/path-to/ivorysql/bin/pg_config
+sudo make PG_CONFIG=/path-to/ivorysql/bin/pg_config install
+----
+
+在测试实例上运行上游回归测试：
+
+[source,bash]
+----
+PGUSER=ivorysql PGPORT=5432 \
+  make PG_CONFIG=/path-to/ivorysql/bin/pg_config installcheck
+----
+
+== 配置本地模式
+
+在 `ivorysql.conf` 中保留已有 IvorySQL 库，并把 `pg_stat_statements` 和 `powa` 追加到 `shared_preload_libraries`：
+
+[source,conf]
+----
+shared_preload_libraries = 'gb18030_2022, liboracle_parser, ivorysql_ora, pg_stat_statements, powa'
+track_io_timing = on
+----
+
+重启 IvorySQL，创建专用数据库，并通过 PostgreSQL 兼容端口安装依赖扩展：
+
+[source,bash]
+----
+pg_ctl restart -D /path-to/data
+createdb -p 5432 powa
+psql -p 5432 -d powa
+----
+
+[source,sql]
+----
+CREATE EXTENSION pg_stat_statements;
+CREATE EXTENSION btree_gist;
+CREATE EXTENSION powa;
+----
+
+生成少量负载并确认快照捕获了语句：
+
+[source,sql]
+----
+SELECT sum(i) FROM generate_series(1, 100) AS g(i);
+SELECT powa_take_snapshot();
+
+SELECT count(*) > 0 AS captured_statements
+FROM powa_statements_history_current;
+----
+
+安装并配置 `powa-web`，使用指向 `powa` 数据库的 PostgreSQL DSN 查看仪表盘。生产环境应把 Web 服务放在启用身份认证和 TLS 的反向代理之后。
+
+== 远程模式
+
+生产环境或需要监控多个实例时，应在专用仓库中安装 PoWA Archivist 并运行 `powa-collector`。每个被监控的 IvorySQL 实例仍需加载并创建 `pg_stat_statements`。使用 PoWA 远程服务器 API 注册实例，再为 collector 配置仓库 DSN。
+
+不要在 `powa_servers` 中保存明文密码。优先使用证书或受保护的密码文件等 libpq 认证方式；条件允许时，使用具有 `pg_read_all_stats` 权限的监控角色而不是超级用户。
+
+== Oracle 兼容模式
+
+[IMPORTANT]
+====
+PoWA 的安装和采集链路应使用 PostgreSQL 兼容端口。在 IvorySQL 5.4 中，通过 Oracle 兼容端口直接创建依赖扩展会失败，因为上游安装脚本使用 PostgreSQL 语法；在交互会话切换到 Oracle 模式后调用 `powa_take_snapshot()` 也可能遇到标识符大小写折叠差异。这些限制不影响 PostgreSQL 模式后台采集，也不影响 PoWA Web 通过 PostgreSQL 端口连接。
+====
+
+Oracle 兼容会话仍可在需要时使用带引号的 schema 和对象名查询工作负载表，但管理配置和快照操作应保持在 PostgreSQL 模式。
+
+生产部署前请阅读 https://powa.readthedocs.io/en/latest/architecture.html[PoWA 架构文档]中的本地与远程方案，以及 https://powa.readthedocs.io/en/latest/security.html[PoWA 安全指南]。

--- a/EN/modules/ROOT/nav.adoc
+++ b/EN/modules/ROOT/nav.adoc
@@ -76,6 +76,7 @@
 *** xref:master/ecosystem_components/zhparser_en.adoc[zhparser]
 *** xref:master/ecosystem_components/pgbackrest.adoc[pgBackRest]
 *** xref:master/ecosystem_components/set_user.adoc[set_user]
+*** xref:master/ecosystem_components/powa.adoc[PoWA]
 * Monitor and O&M
 ** xref:master/getting-started/daily_monitoring.adoc[Monitoring]
 ** xref:master/getting-started/daily_maintenance.adoc[Maintenance]

--- a/EN/modules/ROOT/pages/master/ecosystem_components/ecosystem_overview.adoc
+++ b/EN/modules/ROOT/pages/master/ecosystem_components/ecosystem_overview.adoc
@@ -42,6 +42,7 @@ IvorySQL, as an advanced open-source database compatible with Oracle and based o
 |*28*| xref:master/ecosystem_components/zhparser_en.adoc[zhparser] | master branch | PostgreSQL extension for full-text search of Chinese language (Mandarin Chinese). It implements a Chinese language parser base on the | Search engine、keyword extraction
 |*29*| xref:master/ecosystem_components/pgbackrest.adoc[pgBackRest] | 2.58.0 | pgBackRest is a reliable backup and restore solution for PostgreSQL that seamlessly scales up to the largest databases and workloads | Disaster recovery backup, large database backup, off-site/multi-tier disaster recovery
 | *30* | xref:master/ecosystem_components/set_user.adoc[set_user] | REL4_2_0 | PostgreSQL security auditing extension with controlled role switching, supporting allowlists, enforced auditing, and blocking of high-risk operations | Controlled role switching, privilege management, audit logging
+| *31* | xref:master/ecosystem_components/powa.adoc[PoWA] | 5.3.0 | Collects and visualizes database workload statistics | Performance monitoring, workload analysis, query tuning
 |====
 
 These plugins have all been tested and adapted by the IvorySQL team to ensure stable operation in the IvorySQL environment. Users can select appropriate plugins based on business needs to further enhance the capabilities and flexibility of the database system.

--- a/EN/modules/ROOT/pages/master/ecosystem_components/powa.adoc
+++ b/EN/modules/ROOT/pages/master/ecosystem_components/powa.adoc
@@ -1,0 +1,100 @@
+:sectnums:
+:sectnumlevels: 5
+
+= PoWA
+
+== Overview
+
+PoWA (PostgreSQL Workload Analyzer) collects workload statistics and presents them through a web interface. A complete deployment can contain:
+
+* `powa-archivist`, the database extension that stores and aggregates metrics;
+* `powa-web`, the visualization interface;
+* `powa-collector`, the optional daemon used to collect multiple remote servers.
+
+`pg_stat_statements` is the mandatory primary data source. Other statistics extensions are optional.
+
+This guide was validated on x86_64 Linux with IvorySQL 5.4 (PostgreSQL 18.4) and PoWA Archivist 5.3.0. The extension built without source changes, and all eight upstream PostgreSQL regression tests passed.
+
+== Choose a deployment mode
+
+In *local mode*, PoWA's background worker collects and stores metrics in the monitored IvorySQL instance. This is simple for evaluation, but collection, storage, and visualization queries add load to that instance.
+
+In *remote mode*, `powa-collector` reads statistics from monitored instances and writes them to a dedicated repository. This is the recommended production architecture because it moves storage and visualization overhead away from monitored databases and can monitor read-only standbys.
+
+== Build PoWA Archivist
+
+Install the IvorySQL server development files, then build against the matching `pg_config`:
+
+[source,bash]
+----
+git clone --branch REL_5_3_0 --depth 1 \
+  https://github.com/powa-team/powa-archivist.git
+cd powa-archivist
+
+make PG_CONFIG=/path-to/ivorysql/bin/pg_config
+sudo make PG_CONFIG=/path-to/ivorysql/bin/pg_config install
+----
+
+Run the upstream regression suite against a test instance:
+
+[source,bash]
+----
+PGUSER=ivorysql PGPORT=5432 \
+  make PG_CONFIG=/path-to/ivorysql/bin/pg_config installcheck
+----
+
+== Configure local mode
+
+Append `pg_stat_statements` and `powa` to the existing `shared_preload_libraries` value in `ivorysql.conf`. Preserve the IvorySQL libraries already configured:
+
+[source,conf]
+----
+shared_preload_libraries = 'gb18030_2022, liboracle_parser, ivorysql_ora, pg_stat_statements, powa'
+track_io_timing = on
+----
+
+Restart IvorySQL, create a dedicated database, and install the required extensions through the PostgreSQL-compatible port:
+
+[source,bash]
+----
+pg_ctl restart -D /path-to/data
+createdb -p 5432 powa
+psql -p 5432 -d powa
+----
+
+[source,sql]
+----
+CREATE EXTENSION pg_stat_statements;
+CREATE EXTENSION btree_gist;
+CREATE EXTENSION powa;
+----
+
+Generate a small workload and confirm that a snapshot captures statements:
+
+[source,sql]
+----
+SELECT sum(i) FROM generate_series(1, 100) AS g(i);
+SELECT powa_take_snapshot();
+
+SELECT count(*) > 0 AS captured_statements
+FROM powa_statements_history_current;
+----
+
+Install and configure `powa-web` with a PostgreSQL DSN pointing to the `powa` database to view dashboards. Place the web service behind an authenticated TLS reverse proxy in production.
+
+== Remote mode
+
+For production or multiple monitored instances, install PoWA Archivist in a dedicated repository and run `powa-collector`. Each monitored IvorySQL instance still needs `pg_stat_statements` loaded and created. Register monitored servers with PoWA's remote-server API, then configure the collector with the repository DSN.
+
+Avoid storing plaintext passwords in `powa_servers`. Prefer a supported libpq authentication method such as certificates or a protected password file. Use a monitoring role with `pg_read_all_stats` instead of a superuser where possible.
+
+== Oracle-compatible mode
+
+[IMPORTANT]
+====
+Install and operate PoWA's collection path through the PostgreSQL-compatible port. On IvorySQL 5.4, creating the prerequisites directly through the Oracle-compatible port fails because their upstream installation scripts use PostgreSQL syntax. Calling `powa_take_snapshot()` after switching an interactive session to Oracle mode can also encounter identifier-folding differences. These limitations do not affect PostgreSQL-mode background collection or a PoWA Web connection using the PostgreSQL port.
+====
+
+An Oracle-compatible session can still query workload tables with explicitly quoted schema and object names when required, but administrative setup and snapshot operations should remain in PostgreSQL mode.
+
+See the https://powa.readthedocs.io/en/latest/architecture.html[PoWA architecture documentation] for local and remote designs, and the https://powa.readthedocs.io/en/latest/security.html[PoWA security guidance] before production deployment.


### PR DESCRIPTION
## Summary

- add bilingual PoWA Archivist 5.3.0 build and deployment guidance for IvorySQL 5
- explain local and recommended remote deployment architectures
- document pg_stat_statements, btree_gist, preload, and track_io_timing setup
- include a reproducible snapshot validation workflow
- document security recommendations and verified Oracle-mode limitations
- add PoWA to both navigation files and ecosystem overview tables

## Validation

Validated with IvorySQL 5.4 / PostgreSQL 18.4 and PoWA Archivist 5.3.0:

- source build without PoWA changes — passed
- upstream PostgreSQL regression suite — 8/8 passed
- pg_stat_statements workload capture and powa_take_snapshot — passed
- background worker preload — passed
- Oracle-mode prerequisite installation and identifier-folding limitations — reproduced and documented

Fixes IvorySQL/IvorySQL#1116