### PR TITLE
docs: add lnnvl function documentation

### DIFF
--- a/CN/modules/ROOT/pages/7.8.adoc
+++ b/CN/modules/ROOT/pages/7.8.adoc
@@ -75,6 +75,7 @@
 |compose
 |decompose
 |sys_context
+|lnnvl
 |====
 
 == 内置函数说明
@@ -1150,4 +1151,12 @@ ivorysql=# select sys_context('USERENV','DB_NAME');
  ivorysql
 (1 row)
 
+```
+=== `lnnvl` 函数
+功能：当条件为 FALSE 或 UNKNOWN（NULL）时返回 TRUE，条件为 TRUE 时返回 FALSE。通常用于 WHERE 子句中，以包含条件为假或为 NULL 的行。测试用例如下：
+
+查询值不等于 10 或值为 NULL 的行：
+
+```
+select * from t where lnnvl(a = 10);
 ```

--- a/EN/modules/ROOT/pages/7.8.adoc
+++ b/EN/modules/ROOT/pages/7.8.adoc
@@ -75,6 +75,7 @@
 |compose
 |decompose
 |sys_context
+|lnnvl
 |====
 
 == Built-in function descriptions
@@ -1148,4 +1149,12 @@ ivorysql=# select sys_context('USERENV','DB_NAME');
  ivorysql
 (1 row)
 
+```
+=== `lnnvl` function
+function: return TRUE if the condition is FALSE or UNKNOWN (NULL), and FALSE if the condition is TRUE. It is commonly used in a WHERE clause to also include rows whose condition evaluates to NULL. The test cases are as follows:
+
+Query the rows where the value is not equal to 10 or is NULL:
+
+```
+select * from t where lnnvl(a = 10);
 ```


### PR DESCRIPTION
## Summary

Add the Oracle-compatible `lnnvl` function to the built-in functions documentation.

## Changes

- Add `lnnvl` to the built-in functions table.
- Add a description section documenting `lnnvl` semantics (returns TRUE when the condition is FALSE or NULL) with a usage example.

Updated in both English (`EN/`) and Chinese (`CN/`) docs.

Closes #301