### PR TITLE
docs: add pg_stat_monitor ecosystem component documentation

### DIFF
--- a/CN/modules/ROOT/nav.adoc
+++ b/CN/modules/ROOT/nav.adoc
@@ -52,6 +52,7 @@
 *** xref:5.9.adoc[pgrouting]
 *** xref:5.10.adoc[system_stats]
 *** xref:5.11.adoc[pgtt]
+*** xref:5.13.adoc[pg_stat_monitor]
 *** xref:5.14.adoc[pgnodemx]
 * 监控运维
 ** xref:3.2.adoc[日常监控]

--- a/CN/modules/ROOT/pages/5.13.adoc
+++ b/CN/modules/ROOT/pages/5.13.adoc
@@ -1,0 +1,58 @@
+
+:sectnums:
+:sectnumlevels: 5
+
+= pg_stat_monitor
+
+== 概述
+pg_stat_monitor 是 Percona 开发的 PostgreSQL 查询性能监控扩展。它在一个视图里集中收集查询文本、耗时和等待事件等统计信息。它与 IvorySQL 完全兼容。
+
+== 安装
+
+=== 前置条件
+pg_stat_monitor 需要在服务启动时加载，在 postgresql.conf 中添加：
+
+[literal]
+----
+shared_preload_libraries = 'pg_stat_monitor'
+----
+
+=== 源码安装
+
+[NOTE]
+请确保环境中已安装 **IvorySQL {ivorysql-version} 或以上版本**，且 `pg_config` 在 PATH 中。
+
+[literal]
+----
+$ git clone https://github.com/percona/pg_stat_monitor.git
+$ cd pg_stat_monitor
+$ make USE_PGXS=1
+$ sudo make USE_PGXS=1 install
+----
+
+== 创建扩展并验证
+
+使用 psql 连接数据库，执行以下命令：
+
+[literal]
+----
+ivorysql=# CREATE EXTENSION pg_stat_monitor;
+CREATE EXTENSION
+
+ivorysql=# SELECT * FROM pg_available_extensions WHERE name = 'pg_stat_monitor';
+      name       | default_version | installed_version |       comment
+-----------------+-----------------+-------------------+--------------------
+ pg_stat_monitor | 2.1             | 2.1               | pg_stat_monitor
+----
+
+== 查询统计信息
+
+启用扩展后，查询统计信息收集在 `pg_stat_monitor` 视图中：
+
+[literal]
+----
+ivorysql=# SELECT bucket_start_time, query, calls, total_exec_time
+           FROM pg_stat_monitor
+           ORDER BY total_exec_time DESC
+           LIMIT 5;
+----

--- a/EN/modules/ROOT/nav.adoc
+++ b/EN/modules/ROOT/nav.adoc
@@ -52,6 +52,7 @@
 *** xref:5.9.adoc[pgrouting]
 *** xref:5.10.adoc[system_stats]
 *** xref:5.11.adoc[pgtt]
+*** xref:5.13.adoc[pg_stat_monitor]
 *** xref:5.14.adoc[pgnodemx]
 * Monitor and O&M
 ** xref:3.2.adoc[Monitoring]

--- a/EN/modules/ROOT/pages/5.13.adoc
+++ b/EN/modules/ROOT/pages/5.13.adoc
@@ -1,0 +1,58 @@
+
+:sectnums:
+:sectnumlevels: 5
+
+= pg_stat_monitor
+
+== Overview
+pg_stat_monitor is a query performance monitoring extension for PostgreSQL developed by Percona. It collects statistics in a single view, including query text, timing, and wait events. It is fully compatible with IvorySQL.
+
+== Installation
+
+=== Prerequisites
+pg_stat_monitor must be loaded at server start. Add it to `shared_preload_libraries` in `postgresql.conf`:
+
+[literal]
+----
+shared_preload_libraries = 'pg_stat_monitor'
+----
+
+=== Source Code Installation
+
+[NOTE]
+Please ensure that **IvorySQL {ivorysql-version} or above** is installed and `pg_config` is available in `PATH`.
+
+[literal]
+----
+$ git clone https://github.com/percona/pg_stat_monitor.git
+$ cd pg_stat_monitor
+$ make USE_PGXS=1
+$ sudo make USE_PGXS=1 install
+----
+
+== Create Extension and Verify
+
+Connect to the database with psql and execute the following commands:
+
+[literal]
+----
+ivorysql=# CREATE EXTENSION pg_stat_monitor;
+CREATE EXTENSION
+
+ivorysql=# SELECT * FROM pg_available_extensions WHERE name = 'pg_stat_monitor';
+      name       | default_version | installed_version |       comment
+-----------------+-----------------+-------------------+--------------------
+ pg_stat_monitor | 2.1             | 2.1               | pg_stat_monitor
+----
+
+== Query Statistics
+
+After enabling the extension, query statistics are collected in the `pg_stat_monitor` view:
+
+[literal]
+----
+ivorysql=# SELECT bucket_start_time, query, calls, total_exec_time
+           FROM pg_stat_monitor
+           ORDER BY total_exec_time DESC
+           LIMIT 5;
+----


### PR DESCRIPTION
## Summary

Add the `pg_stat_monitor` ecosystem component adapter doc to the "Eco Component Adaption" section.

## Changes

- Add `EN/modules/ROOT/pages/5.13.adoc` and `CN/modules/ROOT/pages/5.13.adoc` with overview, installation, extension creation and usage.
- Register `5.13.adoc` in both EN and CN nav.

Closes #223