### PR TITLE
docs: add pg_partman ecosystem component documentation

### DIFF
--- a/CN/modules/ROOT/nav.adoc
+++ b/CN/modules/ROOT/nav.adoc
@@ -53,6 +53,7 @@
 *** xref:5.10.adoc[system_stats]
 *** xref:5.11.adoc[pgtt]
 *** xref:5.14.adoc[pgnodemx]
+*** xref:5.15.adoc[pg_partman]
 * 监控运维
 ** xref:3.2.adoc[日常监控]
 ** xref:3.3.adoc[日常维护]

--- a/CN/modules/ROOT/pages/5.15.adoc
+++ b/CN/modules/ROOT/pages/5.15.adoc
@@ -1,0 +1,48 @@
+
+:sectnums:
+:sectnumlevels: 5
+
+= pg_partman
+
+== 概述
+pg_partman 是一个用于管理分区表和索引的 PostgreSQL 扩展。它自动化地创建和维护基于时间或基于序号的分区。它与 IvorySQL 完全兼容。
+
+== 安装
+
+=== 前置条件
+自动后台维护需要 `pg_partman_bgw` 后台工作进程。在 postgresql.conf 中添加：
+
+[literal]
+----
+shared_preload_libraries = 'pg_partman_bgw'
+----
+
+=== 源码安装
+
+[NOTE]
+请确保环境中已安装 **IvorySQL {ivorysql-version} 或以上版本**，且 `pg_config` 在 PATH 中。
+
+[literal]
+----
+$ git clone https://github.com/pgpartman/pg_partman.git
+$ cd pg_partman
+$ make
+$ sudo make install
+----
+
+== 创建扩展并验证
+
+使用 psql 连接数据库，执行以下命令：
+
+[literal]
+----
+ivorysql=# CREATE EXTENSION pg_partman;
+CREATE EXTENSION
+
+ivorysql=# SELECT * FROM pg_available_extensions WHERE name = 'pg_partman';
+    name    | default_version | installed_version |        comment
+------------+-----------------+-------------------+-----------------------
+ pg_partman | 5.2.4           | 5.2.4             | Extension to manage partitioned tables by time or ID
+----
+
+使用与配置请参见 https://github.com/pgpartman/pg_partman/blob/master/doc/pg_partman.md[pg_partman 文档]。

--- a/EN/modules/ROOT/nav.adoc
+++ b/EN/modules/ROOT/nav.adoc
@@ -53,6 +53,7 @@
 *** xref:5.10.adoc[system_stats]
 *** xref:5.11.adoc[pgtt]
 *** xref:5.14.adoc[pgnodemx]
+*** xref:5.15.adoc[pg_partman]
 * Monitor and O&M
 ** xref:3.2.adoc[Monitoring]
 ** xref:3.3.adoc[Maintenance]

--- a/EN/modules/ROOT/pages/5.15.adoc
+++ b/EN/modules/ROOT/pages/5.15.adoc
@@ -1,0 +1,48 @@
+
+:sectnums:
+:sectnumlevels: 5
+
+= pg_partman
+
+== Overview
+pg_partman is a PostgreSQL extension for managing partitioned tables and indexes. It automates the creation and maintenance of time-based and serial-based partitions. It is fully compatible with IvorySQL.
+
+== Installation
+
+=== Prerequisites
+Automatic background maintenance requires the `pg_partman_bgw` background worker. Add it to `shared_preload_libraries` in `postgresql.conf`:
+
+[literal]
+----
+shared_preload_libraries = 'pg_partman_bgw'
+----
+
+=== Source Code Installation
+
+[NOTE]
+Please ensure that **IvorySQL {ivorysql-version} or above** is installed and `pg_config` is available in `PATH`.
+
+[literal]
+----
+$ git clone https://github.com/pgpartman/pg_partman.git
+$ cd pg_partman
+$ make
+$ sudo make install
+----
+
+== Create Extension and Verify
+
+Connect to the database with psql and execute the following commands:
+
+[literal]
+----
+ivorysql=# CREATE EXTENSION pg_partman;
+CREATE EXTENSION
+
+ivorysql=# SELECT * FROM pg_available_extensions WHERE name = 'pg_partman';
+    name    | default_version | installed_version |        comment
+------------+-----------------+-------------------+-----------------------
+ pg_partman | 5.2.4           | 5.2.4             | Extension to manage partitioned tables by time or ID
+----
+
+See the https://github.com/pgpartman/pg_partman/blob/master/doc/pg_partman.md[pg_partman documentation] for usage and configuration.


### PR DESCRIPTION
## Summary

Add the `pg_partman` ecosystem component adapter doc to the "Eco Component Adaption" section.

## Changes

- Add `EN/modules/ROOT/pages/5.15.adoc` and `CN/modules/ROOT/pages/5.15.adoc` with overview, installation, extension creation and usage.
- Register `5.15.adoc` in both EN and CN nav.

Closes #236