### PR TITLE
docs: fix Docker image syntax in installation guides

### DIFF
--- a/CN/modules/ROOT/pages/3.1.adoc
+++ b/CN/modules/ROOT/pages/3.1.adoc
@@ -135,7 +135,7 @@ $ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d 
 ```
 $ docker ps | grep ivorysql
 CONTAINER ID   IMAGE               COMMAND                   CREATED          STATUS          PORTS                              NAMES
-6faa2d0ed705   ivorysql:{ivorysql-version}-ubi8   "docker-entrypoint.s…"   50 seconds ago   Up 49 seconds   5866/tcp, 0.0.0.0:5434->5432/tcp   ivorysql
+6faa2d0ed705   ivorysql/ivorysql:{ivorysql-version}-ubi8   "docker-entrypoint.s…"   50 seconds ago   Up 49 seconds   5866/tcp, 0.0.0.0:5434->5432/tcp   ivorysql
 ```
 
 == 数据库连接

--- a/CN/modules/ROOT/pages/4.6.4.adoc
+++ b/CN/modules/ROOT/pages/4.6.4.adoc
@@ -31,7 +31,7 @@ $ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d 
 ```
 $ docker ps | grep ivorysql
 CONTAINER ID   IMAGE               COMMAND                   CREATED          STATUS          PORTS                              NAMES
-6faa2d0ed705   ivorysql:{ivorysql-version}-ubi8   "docker-entrypoint.s…"   50 seconds ago   Up 49 seconds   5866/tcp, 0.0.0.0:5434->5432/tcp   ivorysql
+6faa2d0ed705   ivorysql/ivorysql:{ivorysql-version}-ubi8   "docker-entrypoint.s…"   50 seconds ago   Up 49 seconds   5866/tcp, 0.0.0.0:5434->5432/tcp   ivorysql
 ```
 
 == podman方式运行

--- a/EN/modules/ROOT/pages/3.1.adoc
+++ b/EN/modules/ROOT/pages/3.1.adoc
@@ -111,7 +111,7 @@ ivorysql  3238  1551  0 20:35 pts/0    00:00:00 grep --color=auto postgres
 
 [source,bash,subs="attributes"]
 ```
-$ docker pull ivorysql/IvorySQL {ivorysql-version}-ubi8
+$ docker pull ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
 TIP: Users in China can also pull from the IvorySQL community Harbor registry for faster downloads, e.g. `docker pull registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
@@ -120,7 +120,7 @@ TIP: Users in China can also pull from the IvorySQL community Harbor registry fo
 
 [source,bash,subs="attributes"]
 ```
-$ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d ivorysql/IvorySQL {ivorysql-version}-ubi8
+$ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
 ** Check if the IvorySQL container is running successfully
@@ -129,7 +129,7 @@ $ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d 
 ```
 $ docker ps | grep ivorysql
 CONTAINER ID   IMAGE               COMMAND                   CREATED          STATUS          PORTS                              NAMES
-6faa2d0ed705   IvorySQL {ivorysql-version}-ubi8   "docker-entrypoint.s…"   50 seconds ago   Up 49 seconds   5866/tcp, 0.0.0.0:5434->5432/tcp   ivorysql
+6faa2d0ed705   ivorysql/ivorysql:{ivorysql-version}-ubi8   "docker-entrypoint.s…"   50 seconds ago   Up 49 seconds   5866/tcp, 0.0.0.0:5434->5432/tcp   ivorysql
 ```
 
 == Connecting to IvorySQL

--- a/EN/modules/ROOT/pages/4.1.adoc
+++ b/EN/modules/ROOT/pages/4.1.adoc
@@ -44,7 +44,7 @@ $ sudo dnf install -y ivorysql5-{ivorysql-version}
 
 [source,bash,subs="attributes"]
 ```
-$ docker pull ivorysql/IvorySQL {ivorysql-version}-ubi8
+$ docker pull ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
 TIP: Users in China can also pull from the IvorySQL community Harbor registry for faster downloads — replace the image reference above with `registry.highgo.com/ivorysql/ivorysql:{ivorysql-version}-ubi8`.
@@ -53,7 +53,7 @@ TIP: Users in China can also pull from the IvorySQL community Harbor registry fo
 
 [source,bash,subs="attributes"]
 ```
-$ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d ivorysql/IvorySQL {ivorysql-version}-ubi8
+$ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 -e Parameter Explanation
 |====
@@ -268,7 +268,7 @@ Stop IvorySQL container and remove IvorySQL image:
 ```
 $ docker stop ivorysql
 $ docker rm ivorysql
-$ docker rmi ivorysql/IvorySQL {ivorysql-version}-ubi8
+$ docker rmi ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
 === Uninstallation for rpm installation

--- a/EN/modules/ROOT/pages/4.6.4.adoc
+++ b/EN/modules/ROOT/pages/4.6.4.adoc
@@ -15,14 +15,14 @@ In addition to Docker Hub, the IvorySQL community also provides a Harbor registr
 
 [source,bash,subs="attributes"]
 ```
-$ docker pull ivorysql/IvorySQL {ivorysql-version}-ubi8
+$ docker pull ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
 ** Running IvorySQL
 
 [source,bash,subs="attributes"]
 ```
-$ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d ivorysql/IvorySQL {ivorysql-version}-ubi8
+$ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
 ** Check if the IvorySQL container is running successfully
@@ -31,7 +31,7 @@ $ docker run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=your_password -d 
 ```
 $ docker ps | grep ivorysql
 CONTAINER ID   IMAGE               COMMAND                   CREATED          STATUS          PORTS                              NAMES
-6faa2d0ed705   IvorySQL {ivorysql-version}-ubi8   "docker-entrypoint.s…"   50 seconds ago   Up 49 seconds   5866/tcp, 0.0.0.0:5434->5432/tcp   ivorysql
+6faa2d0ed705   ivorysql/ivorysql:{ivorysql-version}-ubi8   "docker-entrypoint.s…"   50 seconds ago   Up 49 seconds   5866/tcp, 0.0.0.0:5434->5432/tcp   ivorysql
 ```
 
 == Running with Podman
@@ -40,9 +40,9 @@ CONTAINER ID   IMAGE               COMMAND                   CREATED          ST
 
 [source,bash,subs="attributes"]
 ```
-[highgo@manager-node1 ~]$ podman pull ivorysql/IvorySQL {ivorysql-version}-ubi8
-✔ docker.io/ivorysql/IvorySQL {ivorysql-version}-ubi8
-Trying to pull docker.io/ivorysql/IvorySQL {ivorysql-version}-ubi8...
+[highgo@manager-node1 ~]$ podman pull ivorysql/ivorysql:{ivorysql-version}-ubi8
+✔ docker.io/ivorysql/ivorysql:{ivorysql-version}-ubi8
+Trying to pull docker.io/ivorysql/ivorysql:{ivorysql-version}-ubi8...
 Getting image source signatures
 Copying blob 5885448c5c88 done   |
 Copying blob 6c502b378234 done   |
@@ -65,7 +65,7 @@ Writing manifest to image destination
 
 [source,bash,subs="attributes"]
 ```
-$ podman run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=123456 -d ivorysql/IvorySQL {ivorysql-version}-ubi8
+$ podman run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=123456 -d ivorysql/ivorysql:{ivorysql-version}-ubi8
 ```
 
 ** Check if IvorySQL Container is Running Successfully
@@ -74,7 +74,7 @@ $ podman run --name ivorysql -p 5434:5432 -e IVORYSQL_PASSWORD=123456 -d ivorysq
 ```
 [highgo@manager-node1 ~]$ podman ps | grep ivorysql
 CONTAINER ID            IMAGE                       COMMAND          CREATED          STATUS          PORTS                                 NAMES
-368dee58d5ef  docker.io/ivorysql/IvorySQL {ivorysql-version}-ubi8  postgres    20 seconds ago  Up 20 seconds  0.0.0.0:5434->5432/tcp, 1521/tcp, 5866/tcp  ivorysql
+368dee58d5ef  docker.io/ivorysql/ivorysql:{ivorysql-version}-ubi8  postgres    20 seconds ago  Up 20 seconds  0.0.0.0:5434->5432/tcp, 1521/tcp, 5866/tcp  ivorysql
 
 [highgo@manager-node1 ~]$ podman exec -it ivorysql /bin/bash
 [root@8cc631eb413d /]#


### PR DESCRIPTION
Closes #232

## Summary

- Fix invalid Docker and Podman image references in the installation guides.
- Use the correct `ivorysql/ivorysql:{ivorysql-version}-ubi8` image syntax.
- Keep the Chinese and English example output consistent.

## Validation

- `git diff --check` passes.
- A case-sensitive search confirms that the legacy `ivorysql/IvorySQL {ivorysql-version}-ubi8` syntax no longer remains.
- The corrected syntax matches the image format already documented for the community Harbor registry.