### PR TITLE
docs: add missing ivorysql prefix to Oracle GUCs

### DIFF
--- a/CN/modules/ROOT/pages/master/architecture/guc_framework.adoc
+++ b/CN/modules/ROOT/pages/master/architecture/guc_framework.adoc
@@ -62,7 +62,7 @@
 
 ** 使用方法(以date为例)
 
-查看nls date 的格式及datetime_ignore_nls_mask值
+查看nls date 的格式及ivorysql.datetime_ignore_nls_mask值
 ```
 ivorysql=# set ivorysql.compatible_mode to oracle;
 SET

--- a/CN/modules/ROOT/pages/master/compatibility_features_design/case_conversion.adoc
+++ b/CN/modules/ROOT/pages/master/compatibility_features_design/case_conversion.adoc
@@ -33,7 +33,7 @@ PostmasterMain()-->SetCaseGucOption()-->GetCaseSwitchModeFromControl()
 
 读取到参数值后调用 `SetConfigOption()` 函数进行赋值。
 
-在每个新的后端进程开始的时候，由于是从 `postmaster` 进程 `fork` 而来，会自动拥有相同的 `ivorysql.identifier_case_switch` 参数值。首先处理 `startup` 包，其中如果包含 `database` 或者 `user` 这两个参数，则根据 `identifier_case_switch` 对参数值做相应的处理。
+在每个新的后端进程开始的时候，由于是从 `postmaster` 进程 `fork` 而来，会自动拥有相同的 `ivorysql.identifier_case_switch` 参数值。首先处理 `startup` 包，其中如果包含 `database` 或者 `user` 这两个参数，则根据 `ivorysql.identifier_case_switch` 对参数值做相应的处理。
 
 源代码为：
 

--- a/CN/modules/ROOT/pages/master/compatibility_features_design/nls_parameter.adoc
+++ b/CN/modules/ROOT/pages/master/compatibility_features_design/nls_parameter.adoc
@@ -109,7 +109,7 @@ oravarcharchar(PG_FUNCTION_ARGS)
 }
 ```
 
-=== GUC参数 `datetime_ignore_nls_mask`
+=== GUC参数 `ivorysql.datetime_ignore_nls_mask`
 
 这个参数被定义为一个int值，低四位分别表示是否在相应的日期时间格式上忽略NLS参数的影响，掩码定义如下：
 ```c

--- a/CN/modules/ROOT/pages/master/developer_guide.adoc
+++ b/CN/modules/ROOT/pages/master/developer_guide.adoc
@@ -2174,7 +2174,7 @@ Id  |    flg
 ==== 示例
 
 ```undefined
-set compatible_mode to oracle;
+set ivorysql.compatible_mode to oracle;
 
 create table students(student_id varchar(20) primary key ,
 student_name varchar(40),

--- a/CN/modules/ROOT/pages/master/oracle_compatibility/compat_case_conversion.adoc
+++ b/CN/modules/ROOT/pages/master/oracle_compatibility/compat_case_conversion.adoc
@@ -6,17 +6,17 @@
 
 == 目的
 
-- 为了满足PG和Oracle的引用标识符大小写兼容，ivorysql设计了三种引用标识符的大小写转换模式。通过guc参数“identifier_case_switch”选择转换模式;
+- 为了满足PG和Oracle的引用标识符大小写兼容，ivorysql设计了三种引用标识符的大小写转换模式。通过guc参数“ivorysql.identifier_case_switch”选择转换模式;
 
 == 功能
 
 === 大小写转换的三种模式（默认为interchange）
 
-- 如果 guc参数“identifier_case_switch”值为“normal”
+- 如果 guc参数“ivorysql.identifier_case_switch”值为“normal”
 
    1). 保持双引号所引用的标识符中的字母大小写不变。
 
-- 如果 guc参数“identifier_case_switch”值为“interchange”：
+- 如果 guc参数“ivorysql.identifier_case_switch”值为“interchange”：
 
    1). 如果双引号所引用的标识符中的字母全部为大写，则将大写转换为小写。
 
@@ -24,7 +24,7 @@
 
    3). 如果用双引号引起来的标识符中的字母是大小写混合的，则保持标识符不变。
 
-- 如果 guc参数“identifier_case_switch”值为“lowercase”
+- 如果 guc参数“ivorysql.identifier_case_switch”值为“lowercase”
 
    1). 如果双引号所引用的标识符中的字母全部为大写，则将大写转换为小写。
 

--- a/CN/modules/ROOT/pages/master/oracle_compatibility/compat_nls_parameter.adoc
+++ b/CN/modules/ROOT/pages/master/oracle_compatibility/compat_nls_parameter.adoc
@@ -112,5 +112,5 @@ ivorysql=# show nls_currency;
 ```
 [NOTE]
 ====
-nls_currency和nls_iso_currency的行为，受兼容oracle大小写特性 `identifier_case_switch` 影响
+nls_currency和nls_iso_currency的行为，受兼容oracle大小写特性 `ivorysql.identifier_case_switch` 影响
 ====

--- a/EN/modules/ROOT/pages/master/architecture/guc_framework.adoc
+++ b/EN/modules/ROOT/pages/master/architecture/guc_framework.adoc
@@ -61,7 +61,7 @@ The optional values ​​of this GUC variable are from 0 to 15.
 
 ** Usage Example(date)
 
-check value of **nls_date_format** and **datetime_ignore_nls_mask** 
+check value of **nls_date_format** and **ivorysql.datetime_ignore_nls_mask**
 ```
 ivorysql=# set ivorysql.compatible_mode to oracle;
 SET

--- a/EN/modules/ROOT/pages/master/compatibility_features_design/case_conversion.adoc
+++ b/EN/modules/ROOT/pages/master/compatibility_features_design/case_conversion.adoc
@@ -33,7 +33,7 @@ PostmasterMain()-->SetCaseGucOption()-->GetCaseSwitchModeFromControl()
 
 After reading the parameter value, the `SetConfigOption()` function is called to assign the value.
 
-When each new backend process starts, since it is forked from the `postmaster` process, it automatically has the same `ivorysql.identifier_case_switch` parameter value. First, it processes the `startup` packet, and if it contains `database` or `user` parameters, the parameter values are processed accordingly based on `identifier_case_switch`.
+When each new backend process starts, since it is forked from the `postmaster` process, it automatically has the same `ivorysql.identifier_case_switch` parameter value. First, it processes the `startup` packet, and if it contains `database` or `user` parameters, the parameter values are processed accordingly based on `ivorysql.identifier_case_switch`.
 
 The source code is:
 

--- a/EN/modules/ROOT/pages/master/compatibility_features_design/nls_parameter.adoc
+++ b/EN/modules/ROOT/pages/master/compatibility_features_design/nls_parameter.adoc
@@ -103,7 +103,7 @@ oravarcharchar(PG_FUNCTION_ARGS)
 }
 ```
 
-=== GUC Parameter `datetime_ignore_nls_mask`
+=== GUC Parameter `ivorysql.datetime_ignore_nls_mask`
 
 This parameter is defined as an int value, where the lower four bits indicate whether to ignore NLS parameter influence on the corresponding date-time formats. The mask definitions are:
 ```c

--- a/EN/modules/ROOT/pages/master/oracle_compatibility/compat_case_conversion.adoc
+++ b/EN/modules/ROOT/pages/master/oracle_compatibility/compat_case_conversion.adoc
@@ -6,17 +6,17 @@
 
 == Objective
 
-- In order to meet the case compatibility of PG and Oracle's reference identifiers, ivorysql has designed three case conversion modes for reference identifiers. Select the conversion mode via the GUC parameter "identifier_case_switch";
+- In order to meet the case compatibility of PG and Oracle's reference identifiers, ivorysql has designed three case conversion modes for reference identifiers. Select the conversion mode via the GUC parameter "ivorysql.identifier_case_switch";
 
 == Function
 
 === Three modes of case conversion (interchange by default)
 
-- If the value of the guc parameter "identifier_case_switch" is "normal":
+- If the value of the guc parameter "ivorysql.identifier_case_switch" is "normal":
 
    	1). The letters in the identifier referenced by the double quotation mark are left unchanged.
 
-- If the value of the guc parameter "identifier_case_switch" is "interchange":
+- If the value of the guc parameter "ivorysql.identifier_case_switch" is "interchange":
 
    	1). If the letters in the identifier referenced by the double quotation mark are all uppercase, uppercase is converted to lowercase.
 
@@ -24,7 +24,7 @@
 
     3). If the letters in the identifier enclosed in double quotation marks are mixed-case, the identifier is left unchanged.
 
-- If the value of the guc parameter "identifier_case_switch" is "lowercase":
+- If the value of the guc parameter "ivorysql.identifier_case_switch" is "lowercase":
 
    	1). If the letters in the identifier referenced by the double quotation mark are all uppercase, uppercase is converted to lowercase.
 


### PR DESCRIPTION
Closes #267

## Summary

- Add the full ivorysql. prefix to user-facing Oracle GUC references.
- Cover identifier_case_switch, datetime_ignore_nls_mask, and compatible_mode in English and Chinese documentation.
- Keep internal C variable names unchanged where the design documents intentionally show source code.

## Validation

- git diff --check passes.
- Searched the updated master documentation for the affected GUC names.
- Confirmed the only remaining unprefixed occurrences are internal source-code variables, not user-facing parameter names.